### PR TITLE
Implement basic HTTP upload server

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,4 +22,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+hyper = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+multer = "2"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,6 @@
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
+mod server;
+
 #[tauri::command]
 fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
@@ -8,6 +10,14 @@ fn greet(name: &str) -> String {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .setup(|_app| {
+            tauri::async_runtime::spawn(async {
+                if let Err(e) = server::start().await {
+                    eprintln!("failed to start server: {e}");
+                }
+            });
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- add `hyper`, `tokio` and `multer` deps
- implement `server` module with `/upload` endpoint
- start the server on app setup

## Testing
- `cargo check --offline` *(fails: no matching package named `hyper` found)*
- `cargo check` *(fails to access crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6851f589ffbc832c8d8b72d291090ae3