### PR TITLE
Display HTTP server port

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,12 @@ fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+/// Returns the HTTP server port.
+#[tauri::command]
+fn server_port() -> u16 {
+    server::port()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -18,7 +24,7 @@ pub fn run() {
             });
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![greet, server_port])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1,11 +1,19 @@
 use std::convert::Infallible;
 use std::net::SocketAddr;
 
-use hyper::{Body, Request, Response, Method, StatusCode, Server};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use hyper::service::{make_service_fn, service_fn};
-use tokio::fs::{File, create_dir_all};
-use tokio::io::AsyncWriteExt;
 use multer::Multipart;
+use tokio::fs::{create_dir_all, File};
+use tokio::io::AsyncWriteExt;
+
+/// Port number the HTTP server listens on.
+pub const PORT: u16 = 8080;
+
+/// Returns the port the server listens on.
+pub fn port() -> u16 {
+    PORT
+}
 
 async fn handle_upload(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let dir = std::env::current_dir().unwrap().join("uploads");
@@ -56,8 +64,9 @@ async fn router(req: Request<Body>) -> Result<Response<Body>, Infallible> {
 }
 
 pub async fn start() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let addr: SocketAddr = ([0,0,0,0], 8080).into();
-    let make_service = make_service_fn(|_| async { Ok::<_, Infallible>(service_fn(router)) });
+    let addr: SocketAddr = ([0, 0, 0, 0], PORT).into();
+    let make_service =
+        make_service_fn(|_| async { Ok::<_, Infallible>(service_fn(router)) });
     let server = Server::bind(&addr).serve(make_service);
     println!("HTTP server listening on http://{}", addr);
     tokio::spawn(async move {

--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
         <button type="submit">Greet</button>
       </form>
       <p id="greet-msg"></p>
+      <p id="server-port"></p>
     </main>
   </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ const { invoke } = window.__TAURI__.core;
 
 let greetInputEl;
 let greetMsgEl;
+let serverPortEl;
 
 async function greet() {
   // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -11,6 +12,10 @@ async function greet() {
 window.addEventListener("DOMContentLoaded", () => {
   greetInputEl = document.querySelector("#greet-input");
   greetMsgEl = document.querySelector("#greet-msg");
+  serverPortEl = document.querySelector("#server-port");
+  invoke("server_port").then((port) => {
+    serverPortEl.textContent = `Server running on port ${port}`;
+  });
   document.querySelector("#greet-form").addEventListener("submit", (e) => {
     e.preventDefault();
     greet();


### PR DESCRIPTION
## Summary
- start HTTP server on a fixed port constant
- expose a Tauri command to read the port
- show the port number in the web UI

## Testing
- `cargo build --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6851f72e64b4832c8cf7747b33507491