### PR TITLE
Implement auto-renaming file save

### DIFF
--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -3,9 +3,10 @@ use std::net::SocketAddr;
 
 use hyper::{Body, Method, Request, Response, Server, StatusCode};
 use hyper::service::{make_service_fn, service_fn};
-use multer::Multipart;
-use tokio::fs::{create_dir_all, File};
+use multer::{Field, Multipart};
+use tokio::fs::{create_dir_all, metadata, File};
 use tokio::io::AsyncWriteExt;
+use std::path::{Path, PathBuf};
 
 /// Port number the HTTP server listens on.
 pub const PORT: u16 = 8080;
@@ -16,6 +17,55 @@ pub const MAX_UPLOAD_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 /// Returns the port the server listens on.
 pub fn port() -> u16 {
     PORT
+}
+
+/// Saves a multipart file field to `dir`, returning the path used.
+/// If a file with the same name already exists, a numeric suffix is appended
+/// before the extension.
+async fn save_field(mut field: Field, dir: &Path) -> std::io::Result<PathBuf> {
+    let name = field
+        .file_name()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "file".into());
+
+    let mut path = dir.join(&name);
+    if metadata(&path).await.is_ok() {
+        let stem = Path::new(&name)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("file");
+        let ext = Path::new(&name)
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        let mut i = 1;
+        loop {
+            let candidate = if ext.is_empty() {
+                dir.join(format!("{}_{}", stem, i))
+            } else {
+                dir.join(format!("{}_{i}.{}", stem, ext))
+            };
+            if metadata(&candidate).await.is_err() {
+                path = candidate;
+                break;
+            }
+            i += 1;
+        }
+    }
+
+    let mut file = File::create(&path).await?;
+    let mut written: u64 = 0;
+    while let Some(chunk) = field.chunk().await? {
+        written += chunk.len() as u64;
+        if written > MAX_UPLOAD_SIZE {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "file too large",
+            ));
+        }
+        file.write_all(&chunk).await?;
+    }
+    Ok(path)
 }
 
 async fn handle_upload(req: Request<Body>) -> Result<Response<Body>, Infallible> {
@@ -35,28 +85,17 @@ async fn handle_upload(req: Request<Body>) -> Result<Response<Body>, Infallible>
         }
     };
 
-    while let Ok(Some(mut field)) = multipart.next_field().await {
-        if let Some(name) = field.file_name().map(|s| s.to_string()) {
-            let path = dir.join(name);
-            match File::create(&path).await {
-                Ok(mut file) => {
-                    let mut written: u64 = 0;
-                    while let Ok(Some(chunk)) = field.chunk().await {
-                        written += chunk.len() as u64;
-                        if written > MAX_UPLOAD_SIZE {
-                            return Ok(Response::builder()
-                                .status(StatusCode::PAYLOAD_TOO_LARGE)
-                                .body(Body::from("file too large"))
-                                .unwrap());
-                        }
-                        if let Err(e) = file.write_all(&chunk).await {
-                            eprintln!("write error: {e}");
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("file create error: {e}");
-                }
+    while let Ok(Some(field)) = multipart.next_field().await {
+        match save_field(field, &dir).await {
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::Other && e.to_string() == "file too large" => {
+                return Ok(Response::builder()
+                    .status(StatusCode::PAYLOAD_TOO_LARGE)
+                    .body(Body::from("file too large"))
+                    .unwrap());
+            }
+            Err(e) => {
+                eprintln!("file save error: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- add `save_field` helper in Rust HTTP server
- rename file when a name collision happens during uploads

## Testing
- `cargo check --all-targets` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6851f9da3cc4832cb4f9a097e4cefb45