### PR TITLE
Add SSE progress endpoint

### DIFF
--- a/docs/design-ja.md
+++ b/docs/design-ja.md
@@ -9,6 +9,7 @@
 2. **バックエンド (Rust HTTP サーバ)**
    - `hyper` により HTTP リクエストを処理
    - `/upload` `/healthz` `/events` エンドポイントを公開
+   - `/events` は Server-Sent Events (SSE) で進捗を配信
    - 保存先パスへのファイル書き込みを管理
 3. **通信方式**
    - アップロード進捗は SSE または WebSocket で UI へ送信

--- a/docs/design.md
+++ b/docs/design.md
@@ -9,6 +9,7 @@ This document outlines a high-level design for an Android application that acts 
 2. **Backend (Rust HTTP Server)**
    - Uses `hyper` to handle HTTP requests.
    - Exposes `/upload`, `/healthz`, and `/events` endpoints.
+   - `/events` streams progress updates using Server-Sent Events (SSE).
    - Manages file writes to the configured storage path.
 3. **Communication**
    - Upload progress is streamed to the UI via SSE or WebSocket.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,4 +25,6 @@ serde_json = "1"
 hyper = { version = "1", features = ["full"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 multer = "2"
+once_cell = "1"
+tokio-stream = "0.1"
 


### PR DESCRIPTION
## Summary
- send upload progress through SSE events from Rust server
- document SSE `/events` endpoint in design docs

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68520123f064832c86830850a6707efe