### PR TITLE
Add configurable upload directory on server info page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>File Upload</title>
+</head>
+<body>
+  <h1>Server Info</h1>
+  <div id="info"></div>
+  <form id="dir-form">
+    <label>Upload Directory: <input type="text" id="dir-input" /></label>
+    <button type="submit">Set</button>
+  </form>
+
+  <h1>Upload Files</h1>
+  <form id="upload-form">
+    <input type="file" id="file-input" multiple />
+    <button type="submit">Upload</button>
+  </form>
+  <div id="progress"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,50 @@
+const form = document.getElementById('upload-form');
+const fileInput = document.getElementById('file-input');
+const progress = document.getElementById('progress');
+const info = document.getElementById('info');
+const dirForm = document.getElementById('dir-form');
+const dirInput = document.getElementById('dir-input');
+
+const entries = {};
+
+const events = new EventSource('/events');
+events.onmessage = (e) => {
+  const data = JSON.parse(e.data);
+  let el = entries[data.file];
+  if (!el) {
+    el = document.createElement('div');
+    el.textContent = `${data.file}: starting`;
+    progress.appendChild(el);
+    entries[data.file] = el;
+  }
+  if (data.status === 'progress') {
+    el.textContent = `${data.file}: ${data.bytes} bytes`;
+  } else if (data.status === 'done') {
+    el.textContent = `${data.file}: complete`;
+  }
+};
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fd = new FormData();
+  for (const file of fileInput.files) {
+    fd.append('file', file, file.name);
+  }
+  await fetch('/upload', { method: 'POST', body: fd });
+});
+
+async function loadInfo() {
+  const res = await fetch('/info');
+  if (!res.ok) return;
+  const data = await res.json();
+  info.textContent = `IPs: ${data.ips.join(', ')} Port: ${data.port}`;
+  dirInput.value = data.dir;
+}
+
+dirForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  await fetch('/set_dir', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ dir: dirInput.value }) });
+  loadInfo();
+});
+
+loadInfo();

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,4 +27,5 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 multer = "2"
 once_cell = "1"
 tokio-stream = "0.1"
+local-ip-address = "0.5"
 


### PR DESCRIPTION
## Summary
- show server IPs and port on the main page
- allow editing the upload directory via the web UI
- serve `/info` and `/set_dir` endpoints from the server
- track the upload directory in memory and create it when changed

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_685203cbc694832c9d57e27882f57537